### PR TITLE
override nonce in deploy tx

### DIFF
--- a/src/tasks/setup.ts
+++ b/src/tasks/setup.ts
@@ -48,12 +48,20 @@ const deployTellorModule = async (
 
   const ModuleName = "TellorModule";
   const Module = await hardhatRuntime.ethers.getContractFactory(ModuleName);
+  // get address nonce
+  const nonce = await hardhatRuntime.ethers.provider.getTransactionCount(
+    caller.address
+  );
+  const overrides = {
+    nonce: nonce,
+  };
   const module = await Module.deploy(
     taskArgs.avatar,
     taskArgs.target,
     taskArgs.oracle,
     taskArgs.cooldown,
-    taskArgs.expiration
+    taskArgs.expiration,
+    overrides
   );
   await module.deployTransaction.wait();
   console.log("Module deployed to:", module.address);


### PR DESCRIPTION
- The account nonce kept increasing with each attempt at deploying the module, even when the gas price was set too low and the deploy tx never got included. This fix should allow deploying the tellor module, as long as you update the gasPrice in the hardhat config